### PR TITLE
sendFeatureReport with regular array instead of node Buffer

### DIFF
--- a/lib/setColor.js
+++ b/lib/setColor.js
@@ -10,7 +10,7 @@ module.exports = function(keyboard, region, color, intensity){
 	if (typeof constants.levels[intensity] === 'undefined') throw 'invalid intensity';
 	if (typeof constants.colors[color] === 'undefined') throw 'invalid color';
 
-	var activate = new Buffer(8);
+	var activate = [];
 	// header
 	activate[0] = 1;
 	activate[1] = 2;

--- a/lib/setMode.js
+++ b/lib/setMode.js
@@ -189,7 +189,7 @@ function getColorIntensityLevel (data, region, isRequired) {
 }
 
 function sendData (keyboard, val1, val2, val3, val4) {
-    var data = new Buffer (8);
+    var data = [];
 
     data[0] = 1;
     data[1] = 2;
@@ -204,7 +204,7 @@ function sendData (keyboard, val1, val2, val3, val4) {
 }
 
 function commit (keyboard, mode) {
-    var data = new Buffer (8);
+    var data = [];
 
     data[0] = 1;
     data[1] = 2;


### PR DESCRIPTION
Ref: https://github.com/node-hid/node-hid/issues/122
Ref: https://github.com/node-hid/node-hid/issues/118
Fixes: https://github.com/Kwaadpepper/msi-keyboard-CLI/issues/6
Fixes: #37

This is a temporary work around until node-hid can handle Buffers. ArrayBuffers seem to work under newer node versions (tested on 5.4.1), but they still cause the same issue with older iojs versions (2.5.0).