### PR TITLE
Add Rudimentary Custom Colour Support and add Extra Regions

### DIFF
--- a/lib/constants.json
+++ b/lib/constants.json
@@ -2,7 +2,11 @@
 	"regions": {
 		"left": 1,
 		"middle": 2,
-		"right": 3
+		"right": 3,
+		"logo": 4,
+		"frontLeft": 5,
+		"frontRight" : 6,
+		"touchpad" : 8
 	},
 	"colors": {
 		"black": 0,
@@ -16,10 +20,10 @@
 		"white": 8
 	},
 	"levels": {
-		"light": 3,
-		"low": 2,
-		"med": 1,
-		"high": 0
+		"light": 0.25,
+		"low": 0.50,
+		"med": 0.75,
+		"high": 1.00
 	},
 	"modes": {
 		"normal": 1,

--- a/lib/findKeyboard.js
+++ b/lib/findKeyboard.js
@@ -2,13 +2,15 @@ var hid = require('node-hid');
 var setColor = require('./setColor');
 var setMode = require('./setMode');
 var constants = require('./constants');
+var nodeColor = require('color');
 
 module.exports = function() {
 	var board = new hid.HID(6000, 65280);
 	board.current = {};
 
 	board.color = function(region, obj) {
-    if (typeof obj === 'string') obj = {color: obj};
+    if (typeof obj === 'string') obj = {color: nodeColor(obj)};
+		if (typeof obj.color === 'string') obj.color = nodeColor(obj.color);
 		return setColor(board, region, obj.color, obj.intensity);
 	};
 

--- a/lib/setColor.js
+++ b/lib/setColor.js
@@ -4,9 +4,7 @@ var setMode = require('./setMode');
 module.exports = function(keyboard, region, color, intensity){
 	if (!region) throw 'missing region';
 	if (!color) throw 'missing color';
-	if (!intensity) intensity = 'high'
-
-console.log(color)
+	if (!intensity) intensity = 'high';
 
 	if (typeof constants.regions[region] === 'undefined') throw 'invalid region';
 	if (typeof constants.levels[intensity] === 'undefined') throw 'invalid intensity';

--- a/lib/setColor.js
+++ b/lib/setColor.js
@@ -4,22 +4,27 @@ var setMode = require('./setMode');
 module.exports = function(keyboard, region, color, intensity){
 	if (!region) throw 'missing region';
 	if (!color) throw 'missing color';
-	if (!intensity) intensity = 'high';
+	if (!intensity) intensity = 'high'
+
+console.log(color)
 
 	if (typeof constants.regions[region] === 'undefined') throw 'invalid region';
 	if (typeof constants.levels[intensity] === 'undefined') throw 'invalid intensity';
-	if (typeof constants.colors[color] === 'undefined') throw 'invalid color';
+	if (   (typeof color.red === 'undefined')
+			|| (typeof color.green === 'undefined')
+			|| (typeof color.blue === 'undefined')
+	) throw 'invalid color';
 
 	var activate = [];
 	// header
 	activate[0] = 1;
 	activate[1] = 2;
-	activate[2] = 66; // set color
+	activate[2] = 64; // set color
 	activate[3] = constants.regions[region];
-	activate[4] = constants.colors[color];
-	activate[5] = constants.levels[intensity];
-	activate[6] = 0;
-	activate[7] = 236;  // EOR (end of request)
+	activate[4] = color.red() * constants.levels[intensity];
+	activate[5] = color.green() * constants.levels[intensity];
+	activate[6] = color.blue() * constants.levels[intensity];
+	activate[7] = 0;
 
 	keyboard.sendFeatureReport(activate);
 	setMode(keyboard, keyboard.currentMode || 'normal');
@@ -28,5 +33,6 @@ module.exports = function(keyboard, region, color, intensity){
 		intensity: intensity,
 		color: color
 	};
+
 	return keyboard;
 };


### PR DESCRIPTION
Hi,

Hopefully if I have some time I'll be able to push some more commits to this, in the meantime this should allow arbitrary RGB colours to be used instead of being limited to the predefined ones, for blink and color, will investigate modes tomorrow. Based on the C++ in the ticket from earlier.

Thanks