### PR TITLE
Bumped node-hid dependency version from ^0.5.7 to ^0.7.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "main": "./index.js",
   "dependencies": {
     "color": "^2.0.0",
-    "node-hid": "^0.5.7"
+    "node-hid": "^0.7.4"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
Bumped node-hid dependency version, since node-hid 0.5.* doesn't compile with node 10+. I tested that it works with node 11.6.0 but not with older versions.