### PR TITLE
Use libusb driver to make sure the library can detect MSI Steel Series Keyboard

### DIFF
--- a/lib/findKeyboard.js
+++ b/lib/findKeyboard.js
@@ -4,6 +4,8 @@ var setMode = require('./setMode');
 var constants = require('./constants');
 var nodeColor = require('color');
 
+hid.setDriverType('libusb');
+
 module.exports = function() {
 	var board = new hid.HID(6000, 65280);
 	board.current = {};

--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
   "author": "Steve Lacy <me@slacy.me> (http://slacy.me)",
   "main": "./index.js",
   "dependencies": {
-    "color": "^2.0.0",
-    "node-hid": "^0.7.4"
+    "color": "^3.1.2",
+    "node-hid": "^1.2.0"
   },
   "devDependencies": {
-    "mocha": "*",
-    "should": "*"
+    "mocha": "^7.1.1",
+    "should": "^13.2.3"
   },
   "scripts": {
     "test": "mocha test/main.js test/*.js"

--- a/test/setColor.js
+++ b/test/setColor.js
@@ -1,15 +1,14 @@
 var findKeyboard = require('../lib/findKeyboard');
 var setColor = require('../lib/setColor');
-var should = require('should');
 require('mocha');
 
 describe('msi-keyboard', function() {
   describe('setColor()', function() {
     it('should set the color', function(done) {
-    	var keyboard = findKeyboard();
-    	setColor(keyboard, 'left', 'green', 'high');
-    	setColor(keyboard, 'right', 'red', 'high');
-    	setColor(keyboard, 'middle', 'blue', 'high');
+      var keyboard = findKeyboard();
+      setColor(keyboard, 'left', { red: () => 255, green: () => 0, blue: () => 0 }, 'high');
+      setColor(keyboard, 'right', { red: () => 0, green: () => 255, blue: () => 0 }, 'high');
+      setColor(keyboard, 'middle', { red: () => 0, green: () => 0, blue: () => 255 }, 'high');
       keyboard.close();
       done();
     });


### PR DESCRIPTION
- Use libusb driver to make sure the library can detect MSI Steel Series Keyboard
- Fix failed test setColor.