### PR TITLE
Bump node-hid dependency version to fix #68

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "main": "./index.js",
   "dependencies": {
     "color": "^2.0.0",
-    "node-hid": "^0.5.7"
+    "node-hid": "^0.7.4"
   },
   "devDependencies": {
     "mocha": "*",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "main": "./index.js",
   "dependencies": {
     "color": "^3.1.2",
-    "node-hid": "^1.2.0"
+    "node-hid": "^2.1.1"
   },
   "devDependencies": {
     "mocha": "^7.1.1",


### PR DESCRIPTION
Older version of `node-hid` throws compiler errors. Bumped dependency version to fix #68.